### PR TITLE
Test fixes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+from isp_workbook_parser import Parser
+
+
+@pytest.fixture(scope="session")
+def workbook_v6() -> Parser:
+    workbook = Parser("workbooks/6.0/2024-isp-inputs-and-assumptions-workbook.xlsx")
+    return workbook

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,13 +1,10 @@
 import pytest
 
-from isp_workbook_parser import Parser
 from isp_workbook_parser.parser import TableConfigError
 from isp_workbook_parser.config_model import TableConfig
 
-workbook = Parser("workbooks/6.0/2024-isp-inputs-and-assumptions-workbook.xlsx")
 
-
-def test_end_row_runs_into_another_table_throws_error():
+def test_end_row_runs_into_another_table_throws_error(workbook_v6):
     table_config = TableConfig(
         name="DUMMY",
         sheet_name="Aggregated energy storages",
@@ -20,10 +17,10 @@ def test_end_row_runs_into_another_table_throws_error():
         "incorrectly specified."
     )
     with pytest.raises(TableConfigError, match=error_message):
-        workbook.get_table_from_config(table_config)
+        workbook_v6.get_table_from_config(table_config)
 
 
-def test_end_row_runs_into_notes_throws_error():
+def test_end_row_runs_into_notes_throws_error(workbook_v6):
     table_config = TableConfig(
         name="DUMMY",
         sheet_name="Network Capability",
@@ -35,10 +32,10 @@ def test_end_row_runs_into_notes_throws_error():
         "The first column of the table DUMMY contains the sub string 'Notes:'."
     )
     with pytest.raises(TableConfigError, match=error_message):
-        workbook.get_table_from_config(table_config)
+        workbook_v6.get_table_from_config(table_config)
 
 
-def test_end_row_too_soon_throws_error():
+def test_end_row_too_soon_throws_error(workbook_v6):
     table_config = TableConfig(
         name="DUMMY",
         sheet_name="Network Capability",
@@ -50,10 +47,10 @@ def test_end_row_too_soon_throws_error():
         "There is data in the row after the defined table end for table DUMMY."
     )
     with pytest.raises(TableConfigError, match=error_message):
-        workbook.get_table_from_config(table_config)
+        workbook_v6.get_table_from_config(table_config)
 
 
-def test_end_column_too_soon_throws_error():
+def test_end_column_too_soon_throws_error(workbook_v6):
     table_config = TableConfig(
         name="DUMMY",
         sheet_name="Network Capability",
@@ -65,10 +62,10 @@ def test_end_column_too_soon_throws_error():
         "There is data in the column adjacent to the last column in the table DUMMY."
     )
     with pytest.raises(TableConfigError, match=error_message):
-        workbook.get_table_from_config(table_config)
+        workbook_v6.get_table_from_config(table_config)
 
 
-def test_start_column_too_far_throws_error():
+def test_start_column_too_far_throws_error(workbook_v6):
     table_config = TableConfig(
         name="DUMMY",
         sheet_name="Network Capability",
@@ -80,10 +77,10 @@ def test_start_column_too_far_throws_error():
         "There is data in the column adjacent to the first column in the table DUMMY."
     )
     with pytest.raises(TableConfigError, match=error_message):
-        workbook.get_table_from_config(table_config)
+        workbook_v6.get_table_from_config(table_config)
 
 
-def test_good_config_throws_no_error():
+def test_good_config_throws_no_error(workbook_v6):
     table_config = TableConfig(
         name="DUMMY",
         sheet_name="Network Capability",
@@ -91,4 +88,4 @@ def test_good_config_throws_no_error():
         end_row=21,
         column_range="B:J",
     )
-    workbook.get_table_from_config(table_config)
+    workbook_v6.get_table_from_config(table_config)

--- a/tests/test_packaged_table_configs.py
+++ b/tests/test_packaged_table_configs.py
@@ -7,7 +7,7 @@ workbook_path = Path("workbooks")
 
 @pytest.mark.parametrize("workbook_version_folder", workbook_path.iterdir())
 def test_packaged_table_configs_for_each_version(workbook_version_folder: Path):
-    xl_file = [file for file in workbook_version_folder.glob("*.xls*")]
+    xl_file = [file for file in workbook_version_folder.glob("[!.]*.xls*")]
     assert (
         len(xl_file) == 1
     ), f"There should only be one Excel workbook in each version sub-directory, got {xl_file}"


### PR DESCRIPTION
- Add fixture in `conftest.py` to enable workbook reuse across session
- Exclude lockfiles when globbing workbook version subdirectories