### PR TITLE
fix(7.5): rename CNSW-NNSW table to match plural 'costs_' prefix

### DIFF
--- a/src/isp_table_configs/7.5/flow_path_costs_forecasts.yaml
+++ b/src/isp_table_configs/7.5/flow_path_costs_forecasts.yaml
@@ -30,7 +30,7 @@ flow_path_augmentation_costs_slower_growth_NNSW-SQ:
  column_range: "B:AI"
  columns_with_merged_rows: "B"
 
-flow_path_augmentation_cost_slower_growth_CNSW-NNSW:
+flow_path_augmentation_costs_slower_growth_CNSW-NNSW:
  sheet_name: "Flow path cost forecasts"
  header_rows: 39
  end_row: 44


### PR DESCRIPTION
Fixes #80. The CNSW-NNSW row was the only one in the v7.5 flow-path family using singular `cost_` while the other 41 tables use plural `costs_` — strict-prefix consumers silently dropped it.

```diff
- flow_path_augmentation_cost_slower_growth_CNSW-NNSW:
+ flow_path_augmentation_costs_slower_growth_CNSW-NNSW:
```

Single YAML key rename, single character.