### PR TITLE
Strengthen data_ends_where_expected check to scan all columns after the first

### DIFF
--- a/src/isp_table_configs/6.0/energy_efficiency.yaml
+++ b/src/isp_table_configs/6.0/energy_efficiency.yaml
@@ -21,6 +21,8 @@ energy_efficiency_residential_green_energy_exports:
   header_rows: 29
   end_row: 34
   column_range: "B:AG"
+  # Cell H35, immediately below the table, contains a stray "=SUM(H30:H34)" total that is not part of the table.
+  skip_checks: ["data_ends_where_expected"]
 
 energy_efficiency_residential_reduced:
   sheet_name: "Energy Efficiency"

--- a/src/isp_workbook_parser/parser.py
+++ b/src/isp_workbook_parser/parser.py
@@ -157,28 +157,31 @@ class Parser:
         return sorted_table_names_by_sheet
 
     def _check_data_ends_where_expected(
-        self, tab: str, end_row: int, range: str, name: str
+        self, tab: str, end_row: int, column_range: str, name: str
     ) -> None:
-        """Check that the cell after the last row of the table in the second column is blank.
+        """Check that the cells after the last row of the table, from the second column to the last, are all blank.
 
-        While there are often notes on the data in the first cell after the first column ends, the first cell after the
-        second column ends appears to be always blank. Therefore, checking that this cell is blank can be used to verify
-        that the config has not specified a table end row that is before the actual last row of the table.
+        While there are often notes on the data in the first cell after the first column ends, the cells after the
+        remaining columns end appear to be almost always blank. Therefore, checking that these cells are blank can be
+        used to verify that the config has not specified a table end row that is before the actual last row of the
+        table.
         """
-        first_column = range.split(":")[0]
+        first_column, last_column = column_range.split(":")
         first_col_index = openpyxl.utils.column_index_from_string(first_column)
-        second_col_index = first_col_index + 1
-        # We check that value in the second column is blank because sometime the row after the first column will
-        # contain notes on the data.
-        value_in_second_column_after_last_row = (
-            self.openpyxl_file[tab].cell(row=end_row + 1, column=second_col_index).value
-        )
-        if (
-            value_in_second_column_after_last_row is not None
-            and value_in_second_column_after_last_row not in ["", " ", "\u00a0"]
-        ):
-            error_message = f"There is data in the row after the defined table end for table {name}."
-            raise TableConfigError(error_message)
+        last_col_index = openpyxl.utils.column_index_from_string(last_column)
+        # We don't check the value in the first column because sometimes the row after the table end will
+        # contain notes on the data in the first column.
+        for col_index in range(first_col_index + 1, last_col_index + 1):
+            value_after_last_row = (
+                self.openpyxl_file[tab].cell(row=end_row + 1, column=col_index).value
+            )
+            if value_after_last_row is not None and value_after_last_row not in [
+                "",
+                " ",
+                "\u00a0",
+            ]:
+                error_message = f"There is data in the row after the defined table end for table {name}."
+                raise TableConfigError(error_message)
 
     def _check_no_data_above_first_header_row(
         self, tab: str, header_rows: int, range: str, name: str


### PR DESCRIPTION
## Summary

The `data_ends_where_expected` check previously inspected only the **second column** of the table range in the row after `end_row`. This missed truncated `end_row` configs whenever the second column happened to be blank in the dropped rows — exactly what happened with `marginal_loss_factors_existing_generators` in the 7.8 workbook (PR #86), where the new non-DUID generator rows have a blank second column, so 84 generators were silently dropped with green tests.

The check now scans **every column from the second to the last** of the table range at `end_row + 1`. The first column remains excluded because notes legitimately appear below it.

## Validation

An empirical sweep of all 1,397 tables across workbook versions 6.0, 7.0, 7.3, 7.5 and 7.8 (branch `v7.8`) compared the old and new behaviour. The stricter check fires exactly twice:

- `marginal_loss_factors_existing_generators` (7.8) — the genuine truncation, previously undetected (fix suggested on #86)
- `energy_efficiency_residential_green_energy_exports` (6.0) — a lone stray `=SUM(H30:H34)` total cell in H35 below the table, i.e. a known workbook data artifact, now handled with a commented `skip_checks` entry

Zero other fires across all versions, so no false positives on any currently-correct config. Formula cells intentionally count as data: in the MLF case, some of the cells that betray the truncation are themselves XLOOKUP formulas.

Also renames the check's `range` parameter to `column_range` (it shadowed the builtin, and matches the config field name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)